### PR TITLE
Filename consistency with Overdrive/Source Files

### DIFF
--- a/bakeMetadata.py
+++ b/bakeMetadata.py
@@ -35,15 +35,15 @@ for chap in metadata["chapters"]:
     chapters[chap["spine"]].append(chap)
 
 for file in workingList:
-    if not file.startswith("Chapter "): continue
-    number = file[len("Chapter "):].split(".")[0]
+    if not file.startswith("Part "): continue
+    number = file[len("Part "):].split(".")[0]
     
     audiofile = eyed3.load(os.path.join(workingDir, file))
     if audiofile.tag is None:
         audiofile.initTag()
     else:
         audiofile.tag.clear()
-    audiofile.tag.title = "Disk " + str(int(number))
+    audiofile.tag.title = "Part " + str(int(number))
     audiofile.tag.artist = authorName
     audiofile.tag.images.set(3, coverBytes, coverMime)
     audiofile.tag.album = metadata["title"]

--- a/userscript.js
+++ b/userscript.js
@@ -200,7 +200,7 @@
       const fetchPromises = urls.map(async (url) => {
         const response = await fetch(url.url);
         const blob = await response.blob();
-        const filename = "Chapter " + paddy(url.index + 1, 3) + ".mp3";
+        const filename = "Part " + paddy(url.index + 1, 2) + ".mp3";
 
         let partElem = document.createElement("div");
         partElem.textContent = "Download of "+ filename + " complete";


### PR DESCRIPTION
Overdrive downloads were called "part" instead of "chapter". Chapter implies something different--parts are about 70 minute segments, which may contain one or more book chapters in them.

Also adjusted padding to 2 digits instead of 3, which was in use by Overdrive.

I believe this is also consistent with the source files downloaded by the tool.